### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![MCP Server](https://img.shields.io/badge/MCP-Server-blue)
 ![Version](https://img.shields.io/badge/version-1.1.10-green)
 ![License](https://img.shields.io/badge/license-MIT-blue)
+[![smithery badge](https://smithery.ai/badge/@aindreyway/mcp-codex-keeper)](https://smithery.ai/server/@aindreyway/mcp-codex-keeper)
 
 An intelligent MCP server that serves as a guardian of development knowledge, providing AI assistants with curated access to latest documentation and best practices.
 
@@ -32,6 +33,14 @@ An intelligent MCP server that serves as a guardian of development knowledge, pr
    ```bash
    npm install -g npx
    ```
+
+### Installing via Smithery
+
+To install Aindreyway Codex Keeper for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@aindreyway/mcp-codex-keeper):
+
+```bash
+npx -y @smithery/cli install @aindreyway/mcp-codex-keeper --client claude
+```
 
 ### Configuration
 


### PR DESCRIPTION
This PR makes the following updates to the README:

1. Adds installation instructions for the Aindreyway Codex Keeper on Claude Desktop using Smithery CLI. This provides users with straightforward steps to set up the MCP server.
2. Introduces a badge displaying the number of installations via Smithery, accessible at: https://smithery.ai/server/@aindreyway/mcp-codex-keeper

Feel free to suggest any modifications if necessary!